### PR TITLE
Automatic user group (TA/Instructor/Manager) creation on application startup.

### DIFF
--- a/TAScheduler/apps.py
+++ b/TAScheduler/apps.py
@@ -10,18 +10,22 @@ class TASchedulerAppConfig(AppConfig):
         from django.contrib.contenttypes.models import ContentType
         
         # If they don't already exist, create the TA, Instructor, and Manager groups and assign them the proper permissions.
-        taSchedulerGroups = {
+        
+        taSchedulerGroups = {   # Key is the group name, value is an array of permission codenames.
             'ta': [],
             'instructor': [],
             'manager': [],
         }
         
+        # For each group within the taSchedulerGroups array...
         for groupName, permissions in taSchedulerGroups.items():
+            # If the group doeesn't already exist, create it.
             group, wasCreated = Group.objects.get_or_create(name=groupName)
             
-            if wasCreated:
-                for permissionCodename in permissions:
-                    permission = Permission.objects.get(codename = permissionCodename)
-                    group.permissions.add(permission)
+            if wasCreated:  # Did we just create the group?
+                for permissionCodename in permissions:  # For each permission codename associated with the group...
+                    permission = Permission.objects.get(codename = permissionCodename)  # Get the permission from the database.
+                    group.permissions.add(permission)   # Associate it with the group.
+                
                 print(f'Created \'{groupName}\' group.')
         pass

--- a/TAScheduler/apps.py
+++ b/TAScheduler/apps.py
@@ -1,0 +1,15 @@
+from django.apps import AppConfig
+
+class TASchedulerAppConfig(AppConfig):
+    name = 'TAScheduler'
+    verbose_name = 'TA Scheduler Application'
+
+    def ready(self):
+        # If we imported these models at the top of the file, we'd encounter an error, as they're part of a Django module that isn't loaded at application start.
+        from django.contrib.auth.models import Group, Permission
+        from django.contrib.contenttypes.models import ContentType
+        
+        print("don't awoo $350 penalty")
+        
+        # If they don't already exist, create the TA, Instructor, and Manager groups and assign them the proper permissions.
+        pass

--- a/TAScheduler/apps.py
+++ b/TAScheduler/apps.py
@@ -9,7 +9,19 @@ class TASchedulerAppConfig(AppConfig):
         from django.contrib.auth.models import Group, Permission
         from django.contrib.contenttypes.models import ContentType
         
-        print("don't awoo $350 penalty")
-        
         # If they don't already exist, create the TA, Instructor, and Manager groups and assign them the proper permissions.
+        taSchedulerGroups = {
+            'ta': [],
+            'instructor': [],
+            'manager': [],
+        }
+        
+        for groupName, permissions in taSchedulerGroups.items():
+            group, wasCreated = Group.objects.get_or_create(name=groupName)
+            
+            if wasCreated:
+                for permissionCodename in permissions:
+                    permission = Permission.objects.get(codename = permissionCodename)
+                    group.permissions.add(permission)
+                print(f'Created \'{groupName}\' group.')
         pass

--- a/TAScheduler/settings.py
+++ b/TAScheduler/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'TAScheduler.apps.TASchedulerAppConfig',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Implemented a startup hook which automatically creates the three user groups described in the design document and assigns them the appropriate permissions on application startup.

Currently, the hook doesn't automatically assign any permissions, just due to the fact that we don't have any of our models set up. Once we have that aspect taken care of, it'll be as simple as adding the permission codenames to the arrays associated with each group name within `taSchedulerGroups`.