### PR TITLE
Forcing User to Login to Do Stuff

### DIFF
--- a/TAScheduler/urlTests.py
+++ b/TAScheduler/urlTests.py
@@ -33,6 +33,11 @@ class TestUrls(TestCase):
         self.assertEqual(r.context.request.path, "/accountmanagement/")
 
     def test_homeTemplate(self):
+        User1=User.objects.create_user(username="seth", password="bruh")
+        User1.save()
+        session=self.client.session
+        session["_auth_user_id"]=User1.id
+        session.save()
         r=self.client.get("/")
         self.assertEqual(r.templates[0].name, "index.html")
 
@@ -49,7 +54,7 @@ class TestUrls(TestCase):
 
     def test_homePath(self):
         r=self.client.get("/")
-        self.assertEqual(r.context.request.path, "/")
+        self.assertRedirects("/login/")
 
     def test_profilePath(self):
         Users=User.objects.create_user(username="New Guy", password="testing", email="sethkinney6@gmail.com")

--- a/TAScheduler/urlTests.py
+++ b/TAScheduler/urlTests.py
@@ -32,6 +32,7 @@ class TestUrls(TestCase):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context.request.path, "/accountmanagement/")
 
+
     def test_homeTemplate(self):
         User1=User.objects.create_user(username="seth", password="bruh")
         User1.save()

--- a/TAScheduler/views.py
+++ b/TAScheduler/views.py
@@ -137,6 +137,8 @@ class AccountManagement(View):
 
 class Home(View):
     def get(self, request):
+        if(len(request.session.keys())==0):
+            return redirect("/login/")
         return render(request, "index.html")
 
     def post(self, request):


### PR DESCRIPTION
Just a small little change, that forces a user to login before doing anything. It works by having the home page redirect to the login page if nobody is logged. Since we start at the home page, this will automatically shove us to the login page, and the only way out of the login page is to login. I also updated the url tests to reflect this. 