### PR TITLE
Acceptance tests for sprint 1 PBIs

### DIFF
--- a/TAScheduler/accountcreationacceptancetests.py
+++ b/TAScheduler/accountcreationacceptancetests.py
@@ -1,0 +1,51 @@
+from django.test import TestCase
+from django.test import Client
+from django.contrib.auth.models import User, Group
+from .apps import TASchedulerAppConfig
+from .models import Profile
+
+# As an administrator, I must be able to create accounts for the system, in order to allow new administrators, instructors and TAs to access the system.
+class TestCourseCreationAcceptance(TestCase):
+    def setUp(self):
+        self.client = Client()
+        
+        TASchedulerAppConfig.ready(None)
+        
+        self.userA = User.objects.create_user('jsmith', 'jsmith@example.edu', '123')
+        managerGroup = Group.objects.get(name = 'manager')
+        
+        # GIVEN my account has administrative privileges.
+        managerGroup.user_set.add(self.userA)
+        
+        # AND I am currently logged into my account.
+        self.client.force_login(self.userA)
+    
+    def testSuccessfulAccountCreation(self):
+        # WHEN I submit a new account.
+        response = self.client.post('/accountmanagement/', {'username': 'awest', 'password': '321', 'name': 'Adam West', 'email': 'awest@example.edu'}, follow = True)
+        # THEN the account information is validated by the system.
+        
+        # WHEN the account information is valid.
+        
+        # THEN the account is added to the database.
+        newUser = User.objects.get(username='awest')
+        newProfile = Profile.objects.get(user=newUser)
+        
+        # AND I am redirected to the account management page, which displays the new course.
+        self.assertEqual(response.context.request.path, '/accountmanagement/')
+        self.assertTrue(newUser in response.context['Admin'])
+        self.assertIn(newProfile, response.context['Profiles'])
+    
+    def testUnsuccessfulAccountCreation(self):
+        accounts = User.objects.all()
+        
+        # WHEN I submit a new account.
+        response = self.client.post('/accountmanagement/', {'username': '', 'password': '', 'name': '', 'email': ''}, follow = True)
+        # THEN the account information is validated by the system.
+        
+        # WHEN the account information is invalid.
+        
+        # THEN I am redirected back to the account management page.
+        # AND I am informed that the account information is invalid.
+        self.assertEqual(response.context.request.path, '/accountmanagement/')
+        self.assertEqual(list(response.context['Admin']), list(accounts))

--- a/TAScheduler/coursecreationacceptancetests.py
+++ b/TAScheduler/coursecreationacceptancetests.py
@@ -1,0 +1,62 @@
+from django.test import TestCase
+from django.test import Client
+from django.contrib.auth.models import User, Group
+from .models import Course, Section
+from .apps import TASchedulerAppConfig
+
+# As an administrator, I must be able to create courses within the system, in order to assign them to instructors and TAs.
+class TestCourseCreationAcceptance(TestCase):
+    def setUp(self):
+        self.client = Client()
+        
+        TASchedulerAppConfig.ready(None)
+        
+        self.userA = User.objects.create_user('jsmith', 'jsmith@example.edu', '123')
+        managerGroup = Group.objects.get(name = 'manager')
+        
+        # GIVEN my account has administrative privileges.
+        managerGroup.user_set.add(self.userA)
+        
+        # AND I am currently logged into my account.
+        self.client.force_login(self.userA)
+    
+    def testSuccessfulCourseCreation(self):
+        # WHEN I submit a new course.
+        response = self.client.post('/coursemanagement/', {'coursename': 'CS361', 'coursedescription': 'Introduction to Software Engineering'}, follow = True)
+        # THEN the course information is validated by the system.
+        
+        # WHEN the course information is valid.
+        
+        # THEN the course is added to the database.
+        newCourse = Course.objects.get(name='CS361')
+        
+        # AND I am redirected back to the course management page, which displays the new course.
+        self.assertEqual(response.context.request.path, '/coursemanagement/')
+        self.assertIn(newCourse, response.context['Courses'])
+
+
+    def testUnsuccessfulCourseCreation(self):
+        # WHEN I submit a new course.
+        response = self.client.post('/coursemanagement/', {'coursename': '', 'coursedescription': ''}, follow = True)
+        # THEN the course information is validated by the system.
+        
+        # WHEN the course information is invalid.
+        
+        # THEN I am redirected back to the course management page.
+        # AND I am informed that the course information is invalid.
+        self.assertEqual(response.context.request.path, '/coursemanagement/')
+        self.assertEqual(list(response.context['Courses']), [])
+    
+    def testSectionCreation(self):
+        # GIVEN the course already exists.
+        course = Course.objects.create(name = 'CS361', description = 'Introduction to Software Engineering')
+        
+        # WHEN I press the 'add section' button associated with the course.
+        response = self.client.post('/coursemanagement/', {'course': 'CS361'}, follow = True)
+        
+        # THEN the section is added to the database.
+        newSection = Section.objects.get(name='CS361-001')
+        
+        # AND I am redirected back to the course management page, which displays the new section.
+        self.assertEqual(response.context.request.path, '/coursemanagement/')
+        self.assertIn(newSection, response.context['Sections'])

--- a/TAScheduler/loginacceptancetests.py
+++ b/TAScheduler/loginacceptancetests.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+from django.test import Client
+from django.contrib.auth.models import User
+
+# As a user, I must be able to log into my account, in order to use the system.
+class TestLoginAcceptance(TestCase):
+    def setUp(self):
+        self.client = Client()
+        
+        self.userA = User.objects.create_user('jsmith', 'jsmith@example.edu', '123')
+        self.userB = User.objects.create_user('awest', 'awest@example.edu', '321')
+    
+    def testValid(self):
+        # WHEN I submit a set of credentials.
+        response = self.client.post('/login/', {'name': 'jsmith', 'password': '123'}, follow = True)
+        # THEN the credentials are validated by the system.
+        
+        # WHEN the credentials are valid and authorized for use with this system.
+        # THEN my browser navigates past the login prompt to the system proper.
+        self.assertRedirects(response, '/')
+        self.assertEqual(response.wsgi_request.user, self.userA)
+    
+    def testInvalid(self):
+        # WHEN I submit a set of credentials.
+        response = self.client.post('/login/', {'name': 'jsmith', 'password': '321'}, follow = True)
+        # THEN the credentials are validated by the system.
+        
+        # WHEN the credentials are invalid.
+        # THEN my browser navigates back to the login prompt.
+        # AND I am informed that my credentials are invalid.
+        self.assertEqual(response.context.request.path, '/login/')
+        self.assertNotEqual(response.wsgi_request.user, self.userA)

--- a/TAScheduler/logoutacceptancetests.py
+++ b/TAScheduler/logoutacceptancetests.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from django.test import Client
+from django.contrib.auth.models import User
+
+# As a user, I must be able to log out of my account, in order to ensure my account is not used by someone else.
+class TestLogoutAcceptance(TestCase):
+    def setUp(self):
+        self.client = Client()
+        
+        self.userA = User.objects.create_user("jsmith", "jsmith@example.edu", "123")
+        self.userB = User.objects.create_user("awest", "awest@example.edu", "321")
+        
+        # GIVEN I am currently logged into my account.
+        self.client.force_login(self.userA)
+    
+    def testLogout(self):
+        # WHEN I press the 'log out' button.
+        response = self.client.get("/login/", follow = True)
+        
+        # THEN my session is ended.
+        self.assertNotEqual(response.wsgi_request.user, self.userA)
+        # AND I am returned to the login prompt.
+        self.assertEqual(response.context.request.path, "/login/")

--- a/TAScheduler/views.py
+++ b/TAScheduler/views.py
@@ -63,7 +63,7 @@ class CourseManagement(LoginRequiredMixin, View):
                 newcourse.save()
 
         elif ("course" in request.POST.keys()):
-
+            
             sectioncreationcourse = request.POST["course"]
             targetcourse=Course.objects.filter(name=sectioncreationcourse)[0]
 
@@ -107,25 +107,27 @@ class AccountManagement(LoginRequiredMixin, View):
         return render(request, "usermanagement.html", {"TA":TA, "Instructor":Instructor, "Admin":Admin, "Profiles":Profiles})
 
     def post(self, request):
-        user=request.POST["username"]
-        email=request.POST["email"]
-        name=request.POST["name"]
-        password=request.POST["password"]
-        address=request.POST["address"]
-        phone=request.POST["phone"]
-        altemail=request.POST["altemail"]
-        userthere=User.objects.filter(username=user)
-        groups=Group.objects.filter(name="manager")
-        groupthing=groups[0]
+        if all([(field in request.POST) and (request.POST[field] != '') for field in ['username', 'email', 'name', 'password']]):
+            user=request.POST["username"]
+            email=request.POST["email"]
+            name=request.POST["name"]
+            password=request.POST["password"]
+            address= request.POST.get("address", "")
+            phone=request.POST.get("phone", "")
+            altemail=request.POST.get("altemail", "")
+            userthere=User.objects.filter(username=user)
+            groups=Group.objects.filter(name="manager")
+            groupthing=groups[0]
 
-        if(len(userthere)==0):
+            if(len(userthere)==0):
 
-            newuser=User.objects.create_user(username=user, email=email, first_name=name, password=password)
+                newuser=User.objects.create_user(username=user, email=email, first_name=name, password=password)
 
-            newuser.groups.add(groupthing)
-            newuser.save()
-            newProfile=Profile(user=newuser, address=address, phone=phone, alt_email=altemail)
-            newProfile.save()
+                newuser.groups.add(groupthing)
+                newuser.save()
+                newProfile=Profile(user=newuser, address=address, phone=phone, alt_email=altemail)
+                newProfile.save()
+                
         return redirect("/accountmanagement/")
 
 


### PR DESCRIPTION
Added the following acceptance tests:

- Login (success & failure).
- Logout.
- Account creation (success & failure).
- Course creation (course success/failure & section creation).

I also modified the AccountManagement view to validate the required fields server-side (`username`, `password`, `email`, and `name` in the form).