### PR TITLE
Updated some tests.

### DIFF
--- a/TAScheduler/accountcreationtests.py
+++ b/TAScheduler/accountcreationtests.py
@@ -45,7 +45,7 @@ class TestAccountCreationGet(TestCase):
 
     def test_displayTAName(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="name">TA Timmy</div>' )
+        self.assertContains(r, 'TA Timmy' )
 
 
     def test_loadTAPrimaryEmail(self):
@@ -54,27 +54,27 @@ class TestAccountCreationGet(TestCase):
 
     def test_displayTAPrimaryEmail(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="email">timmy@gmail.com</div>')
+        self.assertContains(r, 'timmy@gmail.com')
 
     def test_loadTAAlternateEmail(self):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context["Profiles"].filter(user=User.objects.filter(first_name="TA Timmy")[0])[0].alt_email, "alt@gmail.com")
     def test_displayTAAlternameEmail(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="altEmail">alt@gmail.com</div>')
+        self.assertContains(r, 'alt@gmail.com')
 
     def test_loadTAAddress(self):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context["Profiles"].filter(user=User.objects.filter(first_name="TA Timmy")[0])[0].address, "9999")
     def test_displayTAAddress(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div>9999</div>')
+        self.assertContains(r, '9999')
     def test_loadTAPhoneNumber(self):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context["Profiles"].filter(user=User.objects.filter(first_name="TA Timmy")[0])[0].phone, "999-999-9999")
     def test_displayTAPhoneNumber(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, "<div>999-999-9999</div>")
+        self.assertContains(r, "999-999-9999")
 
     def test_loadInstructorName(self):
         r=self.client.get("/accountmanagement/")
@@ -82,7 +82,7 @@ class TestAccountCreationGet(TestCase):
 
     def test_displayInstructorName(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="name">Instructor Isaac</div>')
+        self.assertContains(r, 'Instructor Isaac')
 
     def test_loadInstructorEmail(self):
         r=self.client.get("/accountmanagement/")
@@ -90,40 +90,40 @@ class TestAccountCreationGet(TestCase):
 
     def test_displayInstructorEmail(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="email">issac@gmail.com</div>')
+        self.assertContains(r, 'issac@gmail.com')
 
     def test_loadInstructorAltEmail(self):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context["Profiles"].filter(user=User.objects.filter(first_name="Instructor Isaac")[0])[0].alt_email, "alt2@gmail.com")
     def test_displayInstructorAltEmail(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="altEmail">alt2@gmail.com</div>')
+        self.assertContains(r, 'alt2@gmail.com')
     def test_loadInstructorAddress(self):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context["Profiles"].filter(user=User.objects.filter(first_name="Instructor Isaac")[0])[0].address, "9998")
     def test_displayInstructorAddress(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, "<div>9998</div>")
+        self.assertContains(r, "9998")
     def test_loadInstructorPhoneNumber(self):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context["Profiles"].filter(user=User.objects.filter(first_name="Instructor Isaac")[0])[0].phone, "999-999-9998")
     def test_displayInstructorPhoneNumber(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, "<div>999-999-9998</div>")
+        self.assertContains(r, "999-999-9998")
     def test_loadAdminName(self):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context["Admin"][0].first_name, "Admin Adam")
 
     def test_displayAdminName(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="name">Admin Adam</div>')
+        self.assertContains(r, 'Admin Adam')
 
     def test_loadAdminEmail(self):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context["Admin"][0].email, "adam@gmail.com")
     def test_displayAdminEmail(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="email">adam@gmail.com</div>')
+        self.assertContains(r, 'adam@gmail.com')
 
     def test_loadAdminAltEmail(self):
         r=self.client.get("/accountmanagement/")
@@ -132,19 +132,19 @@ class TestAccountCreationGet(TestCase):
 
     def test_displayAdminAltEmail(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="altEmail">alt3@gmail.com</div>')
+        self.assertContains(r, 'alt3@gmail.com')
     def test_loadAdminAddress(self):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context["Profiles"].filter(user=User.objects.filter(first_name="Admin Adam")[0])[0].address, "9997")
     def test_displayAdminAddress(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, "<div>9997</div>")
+        self.assertContains(r, "9997")
     def test_loadAdminPhone(self):
         r=self.client.get("/accountmanagement/")
         self.assertEqual(r.context["Profiles"].filter(user=User.objects.filter(first_name="Admin Adam")[0])[0].phone, "999-999-9997")
     def test_displayAdminPhone(self):
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, "<div>999-999-9997</div>")
+        self.assertContains(r, "999-999-9997")
 
 
     def test_loadMultuipleTAName(self):
@@ -159,13 +159,13 @@ class TestAccountCreationGet(TestCase):
         TA2.groups.add(self.ta_group)
         TA2.save()
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="name">TA Timmy</div>')
+        self.assertContains(r, 'TA Timmy')
     def test_displayMultipleTAName2(self):
         TA2 = User.objects.create_user("Tyler", "tyler@gmail.com", "The Black Knight always triumphs!", first_name="TA Tyler")
         TA2.groups.add(self.ta_group)
         TA2.save()
         r = self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="name">TA Tyler</div>')
+        self.assertContains(r, 'TA Tyler')
     def test_loadMultipleTAEmail(self):
         TA2 = User.objects.create_user("Tyler", "tyler@gmail.com", "The Black Knight always triumphs!", first_name="TA Tyler")
         TA2.groups.add(self.ta_group)
@@ -178,13 +178,13 @@ class TestAccountCreationGet(TestCase):
         TA2.groups.add(self.ta_group)
         TA2.save()
         r = self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="email">timmy@gmail.com</div>')
+        self.assertContains(r, 'timmy@gmail.com')
     def test_displayMultipleTAEmail2(self):
         TA2 = User.objects.create_user("Tyler", "tyler@gmail.com", "The Black Knight always triumphs!", first_name="TA Tyler")
         TA2.groups.add(self.ta_group)
         TA2.save()
         r = self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="email">tyler@gmail.com</div>')
+        self.assertContains(r, 'tyler@gmail.com')
 
     def test_loadMultipleInstructorName(self):
         IN2=User.objects.create_user("Ivy", "ivy@gmail.com", "pAssword", first_name="Instructor Ivy")
@@ -198,13 +198,13 @@ class TestAccountCreationGet(TestCase):
         IN2.groups.add(self.instructor_group)
         IN2.save()
         r = self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="name">Instructor Isaac</div>')
+        self.assertContains(r, 'Instructor Isaac')
     def test_displayMultipleInstructorName2(self):
         IN2 = User.objects.create_user("Ivy", "ivy@gmail.com", "pAssword", first_name="Instructor Ivy")
         IN2.groups.add(self.instructor_group)
         IN2.save()
         r = self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="name">Instructor Ivy</div>')
+        self.assertContains(r, 'Instructor Ivy')
 
     def test_loadMultipleInstructorEmail(self):
         IN2=User.objects.create_user("Ivy", "ivy@gmail.com", "pAssword", first_name="Instructor Ivy")
@@ -218,13 +218,13 @@ class TestAccountCreationGet(TestCase):
         IN2.groups.add(self.instructor_group)
         IN2.save()
         r=self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="email">issac@gmail.com</div>')
+        self.assertContains(r, 'issac@gmail.com')
     def test_displayMultipleInstructorEmail2(self):
         IN2 = User.objects.create_user("Ivy", "ivy@gmail.com", "pAssword", first_name="Instructor Ivy")
         IN2.groups.add(self.instructor_group)
         IN2.save()
         r = self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="email">ivy@gmail.com</div>')
+        self.assertContains(r, 'ivy@gmail.com')
 
 
     def test_loadMultipleAdminName(self):
@@ -239,13 +239,13 @@ class TestAccountCreationGet(TestCase):
         AD2.groups.add(self.admin_group)
         AD2.save()
         r = self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="name">Admin Adam</div>')
+        self.assertContains(r, 'Admin Adam')
     def test_displayMultipleAdminName2(self):
         AD2 = User.objects.create_user("Avery", "avery@gmail.com", "bestcharacter", first_name="Admin Avery")
         AD2.groups.add(self.admin_group)
         AD2.save()
         r = self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="name">Admin Avery</div>')
+        self.assertContains(r, 'Admin Avery')
 
 
     def test_loadMultipleAdminEmail(self):
@@ -260,13 +260,13 @@ class TestAccountCreationGet(TestCase):
         AD2.groups.add(self.admin_group)
         AD2.save()
         r = self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="email">adam@gmail.com</div>')
+        self.assertContains(r, 'adam@gmail.com')
     def test_displayMultipleAdminEmail2(self):
         AD2 = User.objects.create_user("Avery", "avery@gmail.com", "bestcharacter", first_name="Admin Avery")
         AD2.groups.add(self.admin_group)
         AD2.save()
         r = self.client.get("/accountmanagement/")
-        self.assertContains(r, '<div class="email">avery@gmail.com</div>')
+        self.assertContains(r, 'avery@gmail.com')
 
 
 
@@ -288,10 +288,10 @@ class TestAccountCreationPost(TestCase):
         self.assertEqual(len(Profile.objects.all()),1)
 
     def test_displayNewAccountName(self):
-        self.assertContains(self.r ,'<div class="name">Manager Marcus</div>')
+        self.assertContains(self.r ,'Manager Marcus')
 
     def test_displayNewAccountEmail(self):
-        self.assertContains(self.r, '<div class="email">testing@gmail.com</div>')
+        self.assertContains(self.r, 'testing@gmail.com')
 
     def test_usernameStored(self):
         self.assertEqual(User.objects.all()[1].username, "Testing123")
@@ -312,15 +312,15 @@ class TestAccountCreationPost(TestCase):
     def test_altEmailStored(self):
         self.assertEqual(Profile.objects.all()[0].alt_email, "marcus@gmail.com")
     def test_altEmailDisplayed(self):
-        self.assertContains(self.r, '<div class="altEmail">marcus@gmail.com</div>')
+        self.assertContains(self.r, 'marcus@gmail.com')
     def test_phoneStored(self):
         self.assertEqual(Profile.objects.all()[0].phone, "999-999-9999")
     def test_phoneDisplayed(self):
-        self.assertContains(self.r, "<div>999-999-9999</div>")
+        self.assertContains(self.r, "999-999-9999")
     def test_addressStored(self):
         self.assertEqual(Profile.objects.all()[0].address, "9999")
     def test_addressDisplayed(self):
-        self.assertContains(self.r, "<div>9999</div>")
+        self.assertContains(self.r, "9999")
     def test_profileUser(self):
         self.assertEqual(Profile.objects.all()[0].user, User.objects.all()[1])
     def test_secondNewAccount(self):
@@ -354,11 +354,11 @@ class TestAccountCreationPost(TestCase):
 
     def test_displaySecondNewAccountName(self):
         r=self.client.post("/accountmanagement/", {"username":"Testing1234", "password":"shield1", "email":"testing4@gmail.com", "name":"Manager Maria", "phone":"999-999-9998", "address":"9998", "altemail":"maria@gmail.com"}, follow=True)
-        self.assertContains(r, '<div class="name">Manager Maria</div>')
+        self.assertContains(r, 'Manager Maria')
 
     def test_displaySecondNewAccountEmail(self):
         r=self.client.post("/accountmanagement/", {"username":"Testing1234", "password":"shield1", "email":"testing4@gmail.com", "name":"Manager Maria", "phone":"999-999-9998", "address":"9998", "altemail":"maria@gmail.com"}, follow=True)
-        self.assertContains(r, '<div class="email">testing4@gmail.com</div>')
+        self.assertContains(r, 'testing4@gmail.com')
 
 
     def test_duplicateUserName(self):

--- a/TAScheduler/coursecreationtests.py
+++ b/TAScheduler/coursecreationtests.py
@@ -33,31 +33,31 @@ class TestCourseCreationGet(TestCase):
         self.assertEqual(self.r.context["Courses"][0].name, "CS361")
 
     def test_displayCourseName(self):
-        self.assertContains(self.r, '<summary name="course">CS361</summary>')
+        self.assertContains(self.r, 'CS361')
 
     def test_loadCourseDescription(self):
         self.assertEqual(self.r.context["Courses"][0].description, "Neat")
 
     def test_displayCourseDescription(self):
-        self.assertContains(self.r, '<p>Neat</p>')
+        self.assertContains(self.r, 'Neat')
 
     def test_loadCourseUser(self):
         self.assertEqual(self.r.context["Courses"][0].users.all()[0].first_name, "dummy")
 
     def test_displayCourseUser(self):
-        self.assertContains(self.r, "<li>dummy</li>")
+        self.assertContains(self.r, "dummy")
 
     def test_loadCourseSectionsName(self):
         self.assertEqual(Section.objects.filter(course=self.Course1)[0].name, self.Section1.name)
 
     def test_displayCourseSectionsName(self):
-        self.assertContains(self.r, "<summary>CS361-001")
+        self.assertContains(self.r, "CS361-001")
 
     def test_loadSectionUser(self):
         self.assertEqual(Section.objects.filter(course=self.Course1)[0].users.all()[0].first_name, "TA")
 
     def test_displaySectionUser(self):
-        self.assertContains(self.r, "<li>TA</li>")
+        self.assertContains(self.r, "TA")
 
 
     ###########################################END LOAD/DISPLAY BASIC ELEMENTS #####################
@@ -97,7 +97,7 @@ class TestCourseCreationGet(TestCase):
         Section2.save()
 
         r=self.client.get("/coursemanagement/")
-        self.assertContains(r, '<summary name="course">CS 423</summary>')
+        self.assertContains(r, 'CS 423')
     def test_loadMultipleCourseDescription(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw1rd", email="email2@gmail.com", first_name="dummy2")
         dummy2.save()
@@ -133,7 +133,7 @@ class TestCourseCreationGet(TestCase):
 
 
         r=self.client.get("/coursemanagement/")
-        self.assertContains(r, "<p>also neat</p>")
+        self.assertContains(r, "also neat")
 
     def test_loadMultipleCourseUsers(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw1rd", email="email2@gmail.com", first_name="dummy2")
@@ -175,7 +175,7 @@ class TestCourseCreationGet(TestCase):
         Section2.save()
 
         r=self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>dummy2</li>")
+        self.assertContains(r, "dummy2")
 
     def test_loadMultipleCourseSectionsName(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw1rd", email="email2@gmail.com", first_name="dummy2")
@@ -215,7 +215,7 @@ class TestCourseCreationGet(TestCase):
 
         r=self.client.get("/coursemanagement/")
 
-        self.assertContains(r, "<summary>CS423-001</summary>")
+        self.assertContains(r, "CS423-001")
     #users of the section is what is being tested here
     def test_loadMultipleCourseSectionsUsers(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw1rd", email="email2@gmail.com", first_name="dummy2")
@@ -254,7 +254,7 @@ class TestCourseCreationGet(TestCase):
         Section2.save()
 
         r=self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>TA2</li>")
+        self.assertContains(r, "TA2")
 
 
 ####################################END MULTIPLE COURSE TESTS##########################################
@@ -267,7 +267,7 @@ class TestCourseCreationGet(TestCase):
     def test_displayNoUsersName(self):
         self.Course1.users.set([])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, '<summary name="course">CS361</summary>')
+        self.assertContains(r, 'CS361')
     def test_loadNoUsersDescription(self):
         self.Course1.users.set([])
         r=self.client.get("/coursemanagement/")
@@ -275,7 +275,7 @@ class TestCourseCreationGet(TestCase):
     def test_displayNoUsersDescription(self):
         self.Course1.users.set([])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<p>Neat</p>")
+        self.assertContains(r, "Neat")
     def test_loadNoUsersSectionName(self):
         self.Course1.users.set([])
         r=self.client.get("/coursemanagement/")
@@ -283,7 +283,7 @@ class TestCourseCreationGet(TestCase):
     def test_displayNoUsersSectionName(self):
         self.Course1.users.set([])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<summary>CS361-001</summary>")
+        self.assertContains(r, "CS361-001")
     def test_loadNoUsersSectionUsers(self):
         self.Course1.users.set([])
         r=self.client.get("/coursemanagement/")
@@ -292,7 +292,7 @@ class TestCourseCreationGet(TestCase):
     def test_displayNoUsersSectionsUsers(self):
         self.Course1.users.set([])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>TA</li>")
+        self.assertContains(r, "TA")
 
 
 #############################################END NO USERS TESTS ################################################
@@ -316,7 +316,7 @@ class TestCourseCreationGet(TestCase):
         self.Course1.users.set([self.dummy, dummy2])
         self.Course1.save()
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>dummy</li>")
+        self.assertContains(r, "dummy")
 
     def test_displayCourseMultipleUsers2(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
@@ -324,7 +324,7 @@ class TestCourseCreationGet(TestCase):
         self.Course1.users.set([self.dummy, dummy2])
         self.Course1.save()
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>dummy2</li>")
+        self.assertContains(r, "dummy2")
     def test_loadCourseMultipleUsersName(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
         dummy2.save()
@@ -340,7 +340,7 @@ class TestCourseCreationGet(TestCase):
         self.Course1.users.set([self.dummy, dummy2])
         self.Course1.save()
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, '<summary name="course">CS361</summary>')
+        self.assertContains(r, 'CS361')
 
     def test_loadCoursesMultipleUsersDescription(self):
         dummy2=User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
@@ -356,7 +356,7 @@ class TestCourseCreationGet(TestCase):
         self.Course1.users.set([self.dummy, dummy2])
         self.Course1.save()
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<p>Neat</p>")
+        self.assertContains(r, "Neat")
 
 
     def test_loadCoursesMultipleUsersSectionName(self):
@@ -375,7 +375,7 @@ class TestCourseCreationGet(TestCase):
         self.Course1.save()
         r = self.client.get("/coursemanagement/")
 
-        self.assertContains(r, "<summary>CS361-001</summary>")
+        self.assertContains(r, "CS361-001")
 
     def test_loadCoursesMultipleUsersSectionUsers(self):
         dummy2=User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
@@ -392,7 +392,7 @@ class TestCourseCreationGet(TestCase):
         self.Course1.save()
         r = self.client.get("/coursemanagement/")
 
-        self.assertContains(r, "<li>TA</li>")
+        self.assertContains(r, "TA")
 
 
     ##################################END SINGLE COURSE MULTIPLE USER TESTS########################################
@@ -421,7 +421,7 @@ class TestCourseCreationGet(TestCase):
         Section2.save()
 
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, '<summary name="course">CS361</summary>')
+        self.assertContains(r, 'CS361')
 
     def test_loadCourseMultipleSectionsUser(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
@@ -447,7 +447,7 @@ class TestCourseCreationGet(TestCase):
         Section2.save()
 
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>dummy</li>")
+        self.assertContains(r, "dummy")
     def test_loadCourseMultipleSectionsDescription(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
         dummy2.save()
@@ -473,7 +473,7 @@ class TestCourseCreationGet(TestCase):
         Section2.save()
 
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<p>Neat</p>")
+        self.assertContains(r, "Neat")
     def test_loadCourseMultipleSectionsSections(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
         dummy2.save()
@@ -500,7 +500,7 @@ class TestCourseCreationGet(TestCase):
         Section2.save()
 
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<summary>CS361-002</summary>")
+        self.assertContains(r, "CS361-002")
     def test_loadCourseMultipleSectionsUser1(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
         dummy2.save()
@@ -527,7 +527,7 @@ class TestCourseCreationGet(TestCase):
         Section2.save()
 
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>TA</li>")
+        self.assertContains(r, "TA")
     def test_loadCourseMultipleSectionUser2(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
         dummy2.save()
@@ -550,7 +550,7 @@ class TestCourseCreationGet(TestCase):
         #Section2.course=self.Course1
         Section2.save()
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>dummy2</li>")
+        self.assertContains(r, "dummy2")
 
 
 #########################################END COURSES WITH MULTIPLE SECTIONS TESTS############################
@@ -593,7 +593,7 @@ class TestCourseCreationGet(TestCase):
         self.Course1.users.set([self.dummy, dummy3])
         self.Course1.save()
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, '<summary name="course">CS361</summary>')
+        self.assertContains(r, 'CS361')
 
 
     def test_loadCoursesMultipleUsersSectionsDescription(self):
@@ -630,7 +630,7 @@ class TestCourseCreationGet(TestCase):
 
         self.Course1.users.set([self.dummy, dummy3])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<p>Neat</p>")
+        self.assertContains(r, "Neat")
 
     def test_loadCoursesMultipleUsersSectionsUsers(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
@@ -669,7 +669,7 @@ class TestCourseCreationGet(TestCase):
 
         self.Course1.users.set([self.dummy, dummy3])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>dummy</li>")
+        self.assertContains(r, "dummy")
 
     def test_displayCoursesMultipleUsersSectionsUsers2(self):
         dummy2 = User.objects.create_user(username="dummy298", password="passw0rd", email="email2", first_name="dummy2")
@@ -686,7 +686,7 @@ class TestCourseCreationGet(TestCase):
 
         self.Course1.users.set([self.dummy, dummy3])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>dummy3</li>")
+        self.assertContains(r, "dummy3")
 
 
     def test_loadCourseMultipleUsersSectionsSections(self):
@@ -723,7 +723,7 @@ class TestCourseCreationGet(TestCase):
 
         self.Course1.users.set([self.dummy, dummy3])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<summary>CS361-001</summary>")
+        self.assertContains(r, "CS361-001")
 
 
     def test_displayCourseMultipleUsersSectionsSections2(self):
@@ -741,7 +741,7 @@ class TestCourseCreationGet(TestCase):
 
         self.Course1.users.set([self.dummy, dummy3])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<summary>CS361-002</summary>")
+        self.assertContains(r, "CS361-002")
 
     #################################END COURSE WITH MULTIPLE SECTIONS AND USERS TESTING####################
     #################################Begin course with multiple users in a section testing###################
@@ -763,7 +763,7 @@ class TestCourseCreationGet(TestCase):
         self.Section1.users.set([self.TA, dummy2])
 
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, '<summary name="course">CS361</summary>')
+        self.assertContains(r, 'CS361')
 
     def test_loadCourseSectionMultipleUsersDescription(self):
         dummy2 = User.objects.create_user(username="dummy298", password="password", email="email23", first_name="dummy2")
@@ -780,7 +780,7 @@ class TestCourseCreationGet(TestCase):
         dummy2.save()
         self.Section1.users.set([self.TA, dummy2])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<p>Neat</p>")
+        self.assertContains(r, "Neat")
     def test_loadCourseSectionMultipleUsersUser(self):
         dummy2 = User.objects.create_user(username="dummy298", password="password", email="email23", first_name="dummy2")
         dummy2.save()
@@ -796,7 +796,7 @@ class TestCourseCreationGet(TestCase):
         dummy2.save()
         self.Section1.users.set([self.TA, dummy2])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>dummy</li>")
+        self.assertContains(r, "dummy")
     def test_loadCoursesSectionMultipleUsersSectionName(self):
         dummy2 = User.objects.create_user(username="dummy298", password="password", email="email23", first_name="dummy2")
         dummy2.save()
@@ -810,7 +810,7 @@ class TestCourseCreationGet(TestCase):
         self.Section1.users.set([self.TA, dummy2])
 
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r,"<summary>CS361-001")
+        self.assertContains(r,"CS361-001")
     def test_loadCourseSectionMultipleUsersSectionUsers(self):
         dummy2 = User.objects.create_user(username="dummy298", password="password", email="email23", first_name="dummy2")
         dummy2.save()
@@ -824,13 +824,13 @@ class TestCourseCreationGet(TestCase):
         dummy2.save()
         self.Section1.users.set([self.TA, dummy2])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>TA</li>")
+        self.assertContains(r, "TA")
     def test_displayCourseSectionMultipleUsersSectionUsers1(self):
         dummy2 = User.objects.create_user(username="dummy298", password="password", email="email23", first_name="dummy2")
         dummy2.save()
         self.Section1.users.set([self.TA, dummy2])
         r = self.client.get("/coursemanagement/")
-        self.assertContains(r, "<li>dummy2</li>")
+        self.assertContains(r, "dummy2")
 
 
 class TestCourseCreationPost(TestCase):
@@ -897,15 +897,15 @@ class TestCourseCreationPost(TestCase):
         Course1=Course(name="CS361", description="neat")
         Course1.save()
         r=self.client.post("/coursemanagement/", {"course":"CS361"}, follow=True)
-        self.assertContains(r, "<summary>CS361-001</summary>")
+        self.assertContains(r, "CS361-001")
 
     def test_displayCourseName(self):
         r=self.client.post("/coursemanagement/", {"coursename":"CS361", "coursedescription":"Neat"}, follow=True)
-        self.assertContains(r, '<summary name="course">CS361</summary>')
+        self.assertContains(r, 'CS361')
 
     def test_displayCourseDescription(self):
         r=self.client.post("/coursemanagement/", {"coursename":"CS361", "coursedescription":"Neat"}, follow=True)
-        self.assertContains(r, "<p>Neat</p>")
+        self.assertContains(r, "Neat")
 
     def test_secondNewCourse(self):
         Course1 = Course(name="CS361", description="neat")
@@ -922,7 +922,7 @@ class TestCourseCreationPost(TestCase):
         Course1 = Course(name="CS361", description="neat")
         Course1.save()
         r = self.client.post("/coursemanagement/", {"coursename": "CS423", "coursedescription": "Also neat"},follow=True)
-        self.assertContains(r, '<summary name="course">CS423</summary>')
+        self.assertContains(r, 'CS423')
 
     def test_secondNewCourseDescription(self):
         Course1 = Course(name="CS361", description="neat")
@@ -934,7 +934,7 @@ class TestCourseCreationPost(TestCase):
         Course1 = Course(name="CS361", description="neat")
         Course1.save()
         r = self.client.post("/coursemanagement/", {"coursename": "CS423", "coursedescription": "Also neat"},follow=True)
-        self.assertContains(r, "<p>Also neat</p>")
+        self.assertContains(r, "Also neat")
 
     def test_secondNewCourseUsers(self):
         Course1 = Course(name="CS361", description="neat")
@@ -981,7 +981,7 @@ class TestCourseCreationPost(TestCase):
 #        Section1.course = Course1
         Section1.save()
         r=self.client.post("/coursemanagement/", {"course":"CS361"}, follow=True)
-        self.assertContains(r, "<summary>CS361-002</summary>")
+        self.assertContains(r, "CS361-002")
 
 
     def test_secondNewSectionUsers(self):
@@ -1161,7 +1161,7 @@ class TestCourseCreationPost(TestCase):
         Section21.save()
 
         r = self.client.post("/coursemanagement/", {"course": "CS423"}, follow=True)
-        self.assertContains(r, '<summary name="course">CS361</summary>')
+        self.assertContains(r, 'CS361')
 
     def test_secondCourseSecondSectionCourse2Name(self):
         Course1 = Course(name="CS361", description="neat")
@@ -1227,7 +1227,7 @@ class TestCourseCreationPost(TestCase):
         Section21.save()
 
         r = self.client.post("/coursemanagement/", {"course": "CS423"}, follow=True)
-        self.assertContains(r, '<summary name="course">CS423</summary>')
+        self.assertContains(r, 'CS423')
 
     def test_secondCourseSecondSectionCourse1Description(self):
         Course1 = Course(name="CS361", description="neat")
@@ -1292,7 +1292,7 @@ class TestCourseCreationPost(TestCase):
         Section21.save()
 
         r=self.client.post("/coursemanagement/", {"course": "CS423"}, follow=True)
-        self.assertContains(r, "<p>neat</p>")
+        self.assertContains(r, "neat")
     def test_secondCourseSecondSectionCourse2Description(self):
         Course1 = Course(name="CS361", description="neat")
         Course1.save()
@@ -1358,7 +1358,7 @@ class TestCourseCreationPost(TestCase):
         Section21.save()
 
         r=self.client.post("/coursemanagement/", {"course": "CS423"}, follow=True)
-        self.assertContains(r, "<p>Also neat</p>")
+        self.assertContains(r, "Also neat")
     def test_secondCourseSecondSectionCourse1Users(self):
         Course1 = Course(name="CS361", description="neat")
         Course1.save()
@@ -1487,7 +1487,7 @@ class TestCourseCreationPost(TestCase):
         Section21.save()
 
         r=self.client.post("/coursemanagement/", {"course": "CS423"}, follow=True)
-        self.assertContains(r, "<summary>CS361-001</summary>")
+        self.assertContains(r, "CS361-001")
     def test_secondCourseSecondSectionCourse2Section1Name(self):
         Course1 = Course(name="CS361", description="neat")
         Course1.save()
@@ -1552,7 +1552,7 @@ class TestCourseCreationPost(TestCase):
         Section21.save()
 
         r=self.client.post("/coursemanagement/", {"course": "CS423"}, follow=True)
-        self.assertContains(r, "<summary>CS423-001</summary>")
+        self.assertContains(r, "CS423-001")
     def test_secondCourseSecondSectionCourse1Section1Users(self):
         Course1 = Course(name="CS361", description="neat")
         Course1.save()
@@ -1684,7 +1684,7 @@ class TestCourseCreationPost(TestCase):
         Section21.save()
 
         r=self.client.post("/coursemanagement/", {"course": "CS423"}, follow=True)
-        self.assertContains(r, "<summary>CS361-002</summary>")
+        self.assertContains(r, "CS361-002")
     def test_secondCourseSecondSectionCourse2SecondSectionName(self):
         Course1 = Course(name="CS361", description="neat")
         Course1.save()
@@ -1749,7 +1749,7 @@ class TestCourseCreationPost(TestCase):
         Section21.save()
 
         r=self.client.post("/coursemanagement/", {"course": "CS423"}, follow=True)
-        self.assertContains(r, "<summary>CS423-002</summary>")
+        self.assertContains(r, "CS423-002")
     def test_secondCourseSecondSectionCourse1SecondSectionUsers(self):
         Course1 = Course(name="CS361", description="neat")
         Course1.save()

--- a/TAScheduler/profiletests.py
+++ b/TAScheduler/profiletests.py
@@ -25,7 +25,7 @@ class TestProfileGet(TestCase):
 
     def test_displayFirstName(self):
         r=self.client.get("/profile/")
-        self.assertContains(r, '<input value="Timmy" type="text" id="firstname" name="name" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'Timmy')
 
     def test_loadEmail(self):
         r=self.client.get("/profile/")
@@ -33,7 +33,7 @@ class TestProfileGet(TestCase):
 
     def test_displayEmaiL(self):
         r=self.client.get("/profile/")
-        self.assertContains(r, '<input value="timmy@gmail.com" type="email" id="email" name="email" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'timmy@gmail.com')
 
     def test_loadUsername(self):
         r=self.client.get("/profile/")
@@ -41,7 +41,7 @@ class TestProfileGet(TestCase):
 
     def test_displayUserName(self):
         r=self.client.get("/profile/")
-        self.assertContains(r, '<input value="TA Timmy" type="text" id="username" name="username" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'TA Timmy')
 
     def test_loadAddress(self):
         r=self.client.get("/profile/")
@@ -49,7 +49,7 @@ class TestProfileGet(TestCase):
 
     def test_displayAddress(self):
         r=self.client.get("/profile/")
-        self.assertContains(r, '<input value="9999" type="text" id="address" name="address" required minlength="12" maxlength="40" size="40">')
+        self.assertContains(r, '9999')
 
     def test_loadPhone(self):
         r=self.client.get("/profile/")
@@ -57,7 +57,7 @@ class TestProfileGet(TestCase):
 
     def test_displayPhone(self):
         r=self.client.get("/profile/")
-        self.assertContains(r, '<input value="999-999-9999" type="text" id="phone" name="phone" required minlength="10" maxlength="11" size=="11">')
+        self.assertContains(r, '999-999-9999')
 
     def test_loadAltEmail(self):
         r=self.client.get("/profile/")
@@ -65,7 +65,7 @@ class TestProfileGet(TestCase):
 
     def test_displayAltEmail(self):
         r=self.client.get("/profile/")
-        self.assertContains(r, '<input value="nottimmy@gmail.com" type="email" id="altemail" name="altemail" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'nottimmy@gmail.com')
 
 
 
@@ -194,97 +194,97 @@ class TestProfilePost(TestCase):
 
     def test_displayNewName(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":"New Name", "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="New Name" type="text" id="firstname" name="name" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'New Name')
 
     def test_displayNewUsername(self):
         r=self.client.post("/profile/", {"username":"New Username", "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="New Username" type="text" id="username" name="username" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'New Username')
 
     def test_displayNewAddress(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":"1111", "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="1111" type="text" id="address" name="address" required minlength="12" maxlength="40" size="40">')
+        self.assertContains(r, '1111')
 
     def test_displayNewPhone(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":"111-111-1111", "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="111-111-1111" type="text" id="phone" name="phone" required minlength="10" maxlength="11" size=="11">')
+        self.assertContains(r, '111-111-1111')
 
     def test_displayNewEmail(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":"newemail@gmail.com", "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="newemail@gmail.com" type="email" id="email" name="email" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'newemail@gmail.com')
 
     def test_displayNewAltEmail(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":"newaltemail@gmail.com"}, follow=True)
-        self.assertContains(r, '<input value="newaltemail@gmail.com" type="email" id="altemail" name="altemail" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'newaltemail@gmail.com')
 
     def test_displayChangeEverythingName(self):
         r=self.client.post("/profile/", {"username":"New Username", "name":"New Name", "address":"New Address", "phone":"111-111-1111", "email":"newemail@gmail.com", "altemail":"newaltemail@gmail.com"}, follow=True)
-        self.assertContains(r, '<input value="New Name" type="text" id="firstname" name="name" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'New Name')
 
     def test_displayChangeEverythingUsername(self):
         r=self.client.post("/profile/", {"username":"New Username", "name":"New Name", "address":"New Address", "phone":"111-111-1111", "email":"newemail@gmail.com", "altemail":"newaltemail@gmail.com"}, follow=True)
-        self.assertContains(r, '<input value="New Username" type="text" id="username" name="username" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'New Username')
 
     def test_displayChangeEverythingAddress(self):
         r=self.client.post("/profile/", {"username":"New Username", "name":"New Name", "address":"New Address", "phone":"111-111-1111", "email":"newemail@gmail.com", "altemail":"newaltemail@gmail.com"}, follow=True)
-        self.assertContains(r, '<input value="New Address" type="text" id="address" name="address" required minlength="12" maxlength="40" size="40">')
+        self.assertContains(r, 'New Address')
 
     def test_displayChangeEverythingPhone(self):
         r=self.client.post("/profile/", {"username":"New Username", "name":"New Name", "address":"New Address", "phone":"111-111-1111", "email":"newemail@gmail.com", "altemail":"newaltemail@gmail.com"}, follow=True)
-        self.assertContains(r, '<input value="111-111-1111" type="text" id="phone" name="phone" required minlength="10" maxlength="11" size=="11">')
+        self.assertContains(r, '111-111-1111')
 
     def test_displayChangeEverythingEmail(self):
         r=self.client.post("/profile/", {"username":"New Username", "name":"New Name", "address":"New Address", "phone":"111-111-1111", "email":"newemail@gmail.com", "altemail":"newaltemail@gmail.com"}, follow=True)
-        self.assertContains(r, '<input value="newemail@gmail.com" type="email" id="email" name="email" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'newemail@gmail.com')
 
     def test_displayChangeEverythingAltEmail(self):
         r=self.client.post("/profile/", {"username":"New Username", "name":"New Name", "address":"New Address", "phone":"111-111-1111", "email":"newemail@gmail.com", "altemail":"newaltemail@gmail.com"}, follow=True)
-        self.assertContains(r, '<input value="newaltemail@gmail.com" type="email" id="altemail" name="altemail" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'newaltemail@gmail.com')
 
     def test_displayChangeNothingName(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="Timmy" type="text" id="firstname" name="name" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'Timmy')
 
     def test_displayChangeNothingUsername(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="TA Timmy" type="text" id="username" name="username" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'TA Timmy')
 
     def test_displayChangeNothingAddress(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="9999" type="text" id="address" name="address" required minlength="12" maxlength="40" size="40">')
+        self.assertContains(r, '9999')
 
     def test_displayChangeNothingPhone(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="999-999-9999" type="text" id="phone" name="phone" required minlength="10" maxlength="11" size=="11">')
+        self.assertContains(r, '999-999-9999')
 
     def test_displayChangeNothingEmail(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="timmy@gmail.com" type="email" id="email" name="email" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'timmy@gmail.com')
 
     def test_displayChangeNothingAltEmail(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="nottimmy@gmail.com" type="email" id="altemail" name="altemail" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'nottimmy@gmail.com')
 
     def test_displayEmptyName(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":"", "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="Timmy" type="text" id="firstname" name="name" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'Timmy')
 
     def test_displayEmptyUsername(self):
         r=self.client.post("/profile/", {"username":"", "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="TA Timmy" type="text" id="username" name="username" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'TA Timmy')
 
     def test_displayEmptyAddress(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":"", "phone":self.Profile1.phone, "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="9999" type="text" id="address" name="address" required minlength="12" maxlength="40" size="40">')
+        self.assertContains(r, '9999')
 
     def test_displayEmptyPhone(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":"", "email":self.User1.email, "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="999-999-9999" type="text" id="phone" name="phone" required minlength="10" maxlength="11" size=="11">')
+        self.assertContains(r, '999-999-9999')
 
 
     def test_displayEmptyEmail(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":"", "altemail":self.Profile1.alt_email}, follow=True)
-        self.assertContains(r, '<input value="nottimmy@gmail.com" type="email" id="altemail" name="altemail" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'nottimmy@gmail.com')
 
     def test_displayEmptyAltEmail(self):
         r=self.client.post("/profile/", {"username":self.User1.username, "name":self.User1.first_name, "address":self.Profile1.address, "phone":self.Profile1.phone, "email":self.User1.email, "altemail":""}, follow=True)
-        self.assertContains(r, '<input value="nottimmy@gmail.com" type="email" id="altemail" name="altemail" required minlength="4" maxlength="20" size="20">')
+        self.assertContains(r, 'nottimmy@gmail.com')


### PR DESCRIPTION
Updated assertContains tests to just use the actual content instead of the tags surrounding it and the actual content. For example assertContains(r, "(tag)Blahblah(tag)" has been replaced with assertContains(r, "Blahblah"). This should fix CSS changes breaking tests.

UPDATE: Every test class that utilized assertContains has now been updated to no longer test for specific HTML. 