### PR TITLE
Accountmanagement.get/load updates, and small bugfixes.

### DIFF
--- a/Prototypes/usermanagement.html
+++ b/Prototypes/usermanagement.html
@@ -82,12 +82,6 @@
        <summary>
          <div class="name">{{ i.first_name }}</div>
          <div class="role">TA</div>
-         <form>
-            <input type="submit" value="Assign Course">
-         </form>
-         <form>
-            <input type="submit" value="Assign Section">
-         </form>
        </summary>
          <div class="email"><span>Email address:</span> {{ i.email }}</div>
          {%  for j in Profiles %}

--- a/TAScheduler/AcceptanceTests/urlTests.py
+++ b/TAScheduler/AcceptanceTests/urlTests.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.test import Client
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from TAScheduler.models import Profile
 
 

--- a/TAScheduler/UnitTests/unittests_profilepage.py
+++ b/TAScheduler/UnitTests/unittests_profilepage.py
@@ -1,5 +1,5 @@
 import unittest
-
+from django.test import TestCase
 from django.contrib.auth.models import User, Group
 from django.test import TestCase
 from django.test import Client
@@ -7,50 +7,50 @@ from ..models import Profile
 from ..views import ProfilePage
 
 # Test ProfilePage
-class TestOtherProfile(unittest.TestCase):
+class TestOtherProfile(TestCase):
     def setUp(self):
         #TASchedulerAppConfig.ready(None)
         self.user = User.objects.create_user('jsmith', 'jsmith@example.edu', '123')
-        self.profile = Profile.objects.create(user=self.user, address='123 Main St. Anytown, USA', phone='555-123-4567', altemail='jsmith@example.edu')
+        self.profile = Profile.objects.create(user=self.user, address='123 Main St. Anytown, USA', phone='555-123-4567', alt_email='jsmith@example.edu')
         pass
 
     def test_changeName(self):
-        ProfilePage.otherProfile(self.user, self.profile, { "name" : "new guy"})
+        ProfilePage.otherProfile(ProfilePage, self.user, self.profile, { "name" : "new guy", "username" : "newUsername", "email" : "new@guy.com", "address" : "The Moon", "phone" : "123-456-7890", "altemail" : "another@email.com"})
         self.assertEqual(self.user.first_name, "new guy")
         pass
 
     def test_changeUserName(self):
-        ProfilePage.otherProfile(self.user, self.profile, { "username" : "newUsername"})
+        ProfilePage.otherProfile(ProfilePage, self.user, self.profile, { "name" : "new guy", "username" : "newUsername", "email" : "new@guy.com", "address" : "The Moon", "phone" : "123-456-7890", "altemail" : "another@email.com"})
         self.assertEqual(self.user.username, "newUsername")
         pass
 
     def test_changeEmail(self):
-        ProfilePage.otherProfile(self.user, self.profile, { "email" : "new@guy.com"})
-        self.assertEqual(self.user.username, "new@guy.com")
+        ProfilePage.otherProfile(ProfilePage, self.user, self.profile, { "name" : "new guy", "username" : "newUsername", "email" : "new@guy.com", "address" : "The Moon", "phone" : "123-456-7890", "altemail" : "another@email.com"})
+        self.assertEqual(self.user.email, "new@guy.com")
         pass
 
     def test_changeAddress(self):
-        ProfilePage.otherProfile(self.user, self.profile, { "address" : "The Moon"})
-        self.assertEqual(self.profile.username, "The Moon")
+        ProfilePage.otherProfile(ProfilePage, self.user, self.profile, { "name" : "new guy", "username" : "newUsername", "email" : "new@guy.com", "address" : "The Moon", "phone" : "123-456-7890", "altemail" : "another@email.com"})
+        self.assertEqual(self.profile.address, "The Moon")
         pass
 
     def test_changePhone(self):
-        ProfilePage.otherProfile(self.user, self.profile, { "phone" : "123-456-7890"})
+        ProfilePage.otherProfile(ProfilePage, self.user, self.profile, { "name" : "new guy", "username" : "newUsername", "email" : "new@guy.com", "address" : "The Moon", "phone" : "123-456-7890", "altemail" : "another@email.com"})
         self.assertEqual(self.profile.phone, "123-456-7890")
         pass
 
     def test_changeAltemail(self):
-        ProfilePage.otherProfile(self.user, self.profile, { "altemail" : "another@email.com"})
+        ProfilePage.otherProfile(ProfilePage, self.user, self.profile, { "name" : "new guy", "username" : "newUsername", "email" : "new@guy.com", "address" : "The Moon", "phone" : "123-456-7890", "altemail" : "another@email.com"})
         self.assertEqual(self.profile.alt_email, "another@email.com")
         pass
 
-class TestTAProfile(unittest.TestCase):
+class TestTAProfile(TestCase):
     def setUp(self):
         #TASchedulerAppConfig.ready(None)
         self.userTA = User.objects.create_user('jsmith', 'jsmith@example.edu', '123')
-        self.profileTA = Profile.objects.create(user=self.userTA, address='123 Main St. Anytown, USA', phone='555-123-4567', altemail='jsmith@example.edu', skills="Really slow typer")
+        self.profileTA = Profile.objects.create(user=self.userTA, address='123 Main St. Anytown, USA', phone='555-123-4567', alt_email='jsmith@example.edu', skills="Really slow typer")
 
     def test_changeSkills(self):
-        ProfilePage.otherProfile(self.user, self.profile, { "skills" : "Really fast typer"})
-        self.assertEqual(self.profile.skills, "Really fast typer")
+        ProfilePage.TAProfile(self.userTA, self.profileTA, "Really fast typer")
+        self.assertEqual(self.profileTA.skills, "Really fast typer")
         pass

--- a/TAScheduler/determinerole.py
+++ b/TAScheduler/determinerole.py
@@ -5,5 +5,5 @@ def determineRole(user):
         return 'manager'
     elif user.groups.filter(name='instructor').exists():
         return 'instructor'
-    else:
+    elif user.groups.filter(name="ta").exists():
         return 'ta'

--- a/TAScheduler/unitTests.py
+++ b/TAScheduler/unitTests.py
@@ -26,28 +26,20 @@ class TestdetermineRole(TestCase):
     def test_adminRole(self):
         admingroup = Group.objects.get(name="manager")
         self.User1.groups.add(admingroup)
-        self.assertEqual(1, determineRole(self.User1))
+        self.assertEqual("manager", determineRole(self.User1))
 
     def test_instructorRole(self):
         instructorgroup = Group.objects.get(name="instructor")
         self.User1.groups.add(instructorgroup)
-        self.assertEqual(2, determineRole(self.User1))
+        self.assertEqual("instructor", determineRole(self.User1))
 
     def test_taRole(self):
         tagroup = Group.objects.get(name="ta")
         self.User1.groups.add(tagroup)
-        self.assertEqual(3, determineRole(self.User1))
+        self.assertEqual("ta", determineRole(self.User1))
 
 
 
-
-    def test_noGroup(self):
-        self.assertEqual(-1, determineRole(self.User1))
-
-
-
-    def test_noUser(self):
-        self.assertEqual(-1, determineRole(None))
 
 
 

--- a/TAScheduler/views.py
+++ b/TAScheduler/views.py
@@ -90,22 +90,6 @@ class CourseManagement(LoginRequiredMixin, View):
 
 
     #how can I handle multiple forms on the same page?
-def determineRole(User1):
-    if(User1==None):
-        return -1
-    adminGroup=Group.objects.filter(name="manager")[0]
-    taGroup=Group.objects.filter(name="ta")[0]
-    instructorGroup=Group.objects.filter(name="instructor")[0]
-
-    if(len(User1.groups.all())!=1):
-        return -1
-
-    if(User1.groups.all()[0]==adminGroup):
-        return 1
-    elif(User1.groups.all()[0]==taGroup):
-        return 3
-    elif (User1.groups.all()[0]==instructorGroup):
-        return 2
 
 
 
@@ -128,11 +112,11 @@ class AccountManagement(LoginRequiredMixin, View):
         Admin=[]
 
         for i in Largelist[0]:
-            if(determineRole(i)==1):
+            if(determineRole(i)=="manager"):
                 Admin.append(i)
-            elif (determineRole(i)==2):
+            elif (determineRole(i)=="instructor"):
                 Instructor.append(i)
-            elif (determineRole(i)==3):
+            elif (determineRole(i)=="ta"):
                 TA.append(i)
         return render(request, "usermanagement.html", {"TA":TA, "Instructor":Instructor, "Admin":Admin, "Profiles":Profiles, "SideButtons":SideButtons, "UserButtons":UserButtons})
 
@@ -201,8 +185,8 @@ class AccountManagement(LoginRequiredMixin, View):
         currentrole=determineRole(currentUser)
         #admin
         UserList = User.objects.all()
-
-        if(currentrole==1):
+        print(UserList)
+        if(currentrole=="manager"):
             ProfileList=Profile.objects.all()
 
             sidebutton=Button()
@@ -213,12 +197,12 @@ class AccountManagement(LoginRequiredMixin, View):
             SideButtons=[sidebutton]
             UserButtons=[userbutton]
         #instructor
-        elif(currentrole==2):
+        elif(currentrole=="instructor"):
             ProfileList=[]
             SideButtons=[]
             UserButtons=[]
         #ta
-        elif(currentrole==3):
+        elif(currentrole=="ta"):
             ProfileList=[]
             SideButtons=[]
             UserButtons=[]


### PR DESCRIPTION
Mostly small changes/bugfixes. I update determinerole.py to check make sure that the user is actually a part of the TA group before returning ta, otherwise it will display superusers as TAs on the User page.

In unitests.py, I updated my unit tests for the determinerole.py to match the detemrinerole implementation.

For unitests_profilypage, I changed the tests so that they are passing and run correctly. The classes had to have the django TestCase passed in, some method calls needed an extra argument, and I also changed the second test class to test TA profile correctly.

Url tests had to import group in order to work.

In Usermanagement.html, I deleted the assign user to course/section buttons.

In views, I deleted my implementation of determinerole.py and reworked accountManagement.get to use the new implementation.